### PR TITLE
feat(ivoox): iterate over all the podcast pages

### DIFF
--- a/plugins/ivoox.py
+++ b/plugins/ivoox.py
@@ -17,6 +17,13 @@ class PluginImpl(Plugin):
         response = requests.get(url)
         sel = Selector(response.text)
         videos = sel.css('.modulo-type-episodio')
+        while True:
+            next_page_url = sel.css('.pagination li:last-child a::attr(href)').get()
+            if next_page_url == '#':
+                break
+            response = requests.get(next_page_url)
+            sel = Selector(response.text)
+            videos.extend(sel.css('.modulo-type-episodio'))
         return PodcastFeed(
             feed_id=feed_id,
             title=clean(sel.css('#list_title_new::text').get()),


### PR DESCRIPTION
A small patch that iterates over all the pages of the podcast to add all the elements to the feed.

I understand that it may be a performance problem if there are too many pages, a query parameter could be added to control whether the complete list is desired.
