### PR TITLE
feat(ivoox): skip podcast items with support badge

### DIFF
--- a/plugins/ivoox.py
+++ b/plugins/ivoox.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Union
 
 import dateparser
 import requests
@@ -40,9 +40,12 @@ class PluginImpl(Plugin):
         return f'http://www.ivoox.com/listen_mn_{podcast_id}.m4a?internal=HTML5'
 
     def _get_items(self, items: SelectorList) -> List[PodcastItem]:
-        return [self._get_item(item) for item in items]
+        return [item for item in (self._get_item(item) for item in items) if item is not None]
 
-    def _get_item(self, item: Selector) -> PodcastItem:
+    def _get_item(self, item: Selector) -> Union[PodcastItem, None]:
+        has_support_badge = item.css('.title-wrapper span.fan-title').get() != None
+        if has_support_badge == True:
+            return None
         url = item.css('.title-wrapper a::attr(href)').get()
         re_item_id = re.match(r'https?://www\.ivoox\.com/([-_\w\d]+)\.html', url)
         item_id = re_item_id and re_item_id.group(1)


### PR DESCRIPTION
The next patch will omit from the feed those items that are not complete.

As an example, the [following podcast](https://www.ivoox.com/podcast-danko_sq_f11313_1.html) has items with the support badge:

<img width="725" src="https://github.com/dyeray/podtube/assets/1217588/848e3471-a890-47a3-9d13-f0b22bdb737b">

for the item <https://www.ivoox.com/ciber-angel-guarda-crackeo-y-audios-mp3_rf_109878282_1.html>, the target audio source is <http://www.ivoox.com/listen_mn_109878282_1.m4a?internal=HTML5> which has a duration of _8:11_ instead of the expected duration of _27:14_.