### PR TITLE
ci(build-push-image): GitHub action workflow docker image

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,48 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+env:
+  ACT_REGISTRY: ghcr.io
+  ACT_IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACT_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.ACT_REGISTRY }}/${{ env.ACT_IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,5 @@
+services:
+  podtube:
+    image: ghcr.io/dyeray/podtube:latest
+    ports:
+      - 8080:8080


### PR DESCRIPTION
A GitHub action workflow to create Docker images of the project using the GitHub container registry.

Is a multi-platform image, the platforms supported are _linux/amd64_ and _linux/arm64_.

It'll create a _latest_ image (`ghcr.io/dyeray/podtube:latest`) on any push to the master branch, and a _tag version_ image (`ghcr.io/dyeray/podtube:1.2.3`) on any git tag push.

A _compose.yml_ file is added for convenience as well.