### PR TITLE
build(docker): non root container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# general
+/.gitignore
+/.git
+/.github
+/.vscode
+
+# app
+/.flake8
+/compose.yml
+/pytest.ini
+/README.md
+/requirements.dev.txt
+/test
+
+# misc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the project files
 COPY . .
 
+# Non-root user
+USER www-data
+
 # Expose the server port
 EXPOSE 8080
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,6 +37,8 @@
     </p>
     <h3>format</h3>
     <p>Output format of the feed. Accepted values are rss and atom. The default value is rss.</p>
+    <h3>max_pagination</h3>
+    <p>Number of pages for which results are desired. The default value is 1.</p>
     <h3>proxy_url</h3>
     <p>
       Whether the feed will contain urls that point directly to the files on the original services, or if it points to podtube so the final urls are generated on the fly.


### PR DESCRIPTION
Improves the container security by using a non-root user, avoiding potential privilege escalation.
Since writing to file system is not needed, the user will not have write permissions over the application files.
Added missing documentation of max_pagination parameter, feel free to improve it.