### PR TITLE
Add episode links

### DIFF
--- a/core/feed.py
+++ b/core/feed.py
@@ -22,7 +22,8 @@ def render_feed(feed_id: str, plugin: Plugin, options: GlobalOptions, base_url: 
                 media=Media(generate_url(episode, plugin, options, base_url), episode.content_length, type=episode.content_type),
                 summary=episode.description,
                 publication_date=episode.date,
-                image=episode.image
+                image=episode.image,
+                link=episode.link
             ) for episode in feed.items
         ]
     )

--- a/core/feed.py
+++ b/core/feed.py
@@ -20,7 +20,7 @@ def render_feed(feed_id: str, plugin: Plugin, options: GlobalOptions, base_url: 
                 id=episode.item_id,
                 title=episode.title,
                 media=Media(generate_url(episode, plugin, options, base_url), episode.content_length, type=episode.content_type),
-                summary=episode.description,
+                summary=episode.description.replace("\n", "<br>") if episode.description and options.html_newlines else episode.description,
                 publication_date=episode.date,
                 image=episode.image,
                 link=episode.link

--- a/core/model.py
+++ b/core/model.py
@@ -8,6 +8,7 @@ class PodcastItem:
     item_id: str
     title: str
     description: str
+    link: str
     date: datetime
     image: str
     content_type: str

--- a/core/options.py
+++ b/core/options.py
@@ -17,6 +17,7 @@ class GlobalOptions(Options):
     proxy_url: bool = True
     proxy_download: bool = False
     icon: str = None
+    html_newlines: bool = True
 
 
 class Choice(str, Enum):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import os
 import httpx
 from flask import Flask, request, Response, render_template, redirect, stream_with_context
 
@@ -35,11 +34,6 @@ def download():
         return Response(stream_with_context(req.iter_content()), content_type=req.headers['content-type'])
     else:
         return redirect(url, code=302)
-
-
-@app.route("/redirect/<path:path>")
-def proxy(path):
-    return redirect('https://' + os.getenv('REDIRECT_DOMAIN') + "/" + path, code=302)
 
 
 @app.route('/health-check')

--- a/plugins/invidious.py
+++ b/plugins/invidious.py
@@ -58,6 +58,7 @@ class PluginImpl(Plugin):
             item_id=video_id,
             title=entry.css('title::text').get(),
             description=entry.css('description::text').get(),
+            link=f"https://{self.options.domain}/watch?v={video_id}",
             date=datetime.fromisoformat(entry.css('published::text').get()),
             image=entry.css('group > thumbnail::attr(url)').get(),
             content_type="video/mp4",

--- a/plugins/invidious.py
+++ b/plugins/invidious.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 
+import ftfy
 import httpx
 from parsel import Selector, SelectorList
 
@@ -54,10 +55,11 @@ class PluginImpl(Plugin):
 
     def _get_item(self, entry: Selector):
         video_id = entry.css('videoId::text').get()
+        description = entry.css('description::text').get()
         return PodcastItem(
             item_id=video_id,
             title=entry.css('title::text').get(),
-            description=entry.css('description::text').get(),
+            description=description and ftfy.fix_text(description),
             link=f"https://{self.options.domain}/watch?v={video_id}",
             date=datetime.fromisoformat(entry.css('published::text').get()),
             image=entry.css('group > thumbnail::attr(url)').get(),

--- a/plugins/ivoox.py
+++ b/plugins/ivoox.py
@@ -64,6 +64,7 @@ class PluginImpl(Plugin):
             item_id=item_id,
             title=item.css('.title-wrapper a::attr(title)').get(),
             description=item.css('.audio-description button::attr(data-content)').get() or '',
+            link=f"https://www.ivoox.com/{item_id}.html",
             date=date,
             image=self._get_episode_image(item),
             content_type='audio/mp4',

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -34,7 +34,7 @@ class PluginImpl(Plugin):
             feed_id=feed_id,
             title=title,
             description=title,
-            link='https://www.youtube.com/channel/' + feed_id,
+            link=f'https://www.youtube.com/channel/{feed_id}',
             image="",
             items=self._get_items(entries)
         )
@@ -55,6 +55,7 @@ class PluginImpl(Plugin):
             item_id=video_id,
             title=entry.css('title::text').get(),
             description=entry.css('group > description::text').get(),
+            link=f'https://www.youtube.com/watch?v={video_id}',
             date=datetime.fromisoformat(entry.css('published::text').get()),
             image=entry.css('group > thumbnail::attr(url)').get(),
             content_type="video/mp4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx==0.25.0
 parsel==1.8.1
 dateparser==1.1.8
 pydantic==2.4.2
+ftfy==6.1.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,12 @@
     This option is provided just in case the service forces that the same IP that generates the download link is the only one with permissions to download.
     Note that this option may not work on PaaS like Heroku, as long requests are usually not allowed there.
   </p>
+  <h3>html_newlines</h3>
+  <p>
+    With this option, newlines in the podcast entries' description will be replaced by <br>, in order to show the description correctly.
+    This can be extended to other feed parts in the future if needed.
+    By default it is true
+  </p>
 
   <h2>Examples</h2>
 


### PR DESCRIPTION
This PR adds the original episode link, so podtube feeds can be used on a regular feed reader to open the episode and listen in the website. This may be useful specially for invidious, as usually different instances dissapear and new ones appear. This way you can have your podtube urls on your feeds instead of the specific invidious instance and when the invidious instance has to be changed only one config in podtube needs to be updated, instead of several urls in your feed reader.

This was the idea behind the /redirect endpoint. And since it never worked correctly, I'm removing it on this PR too.