### PR TITLE
podtube v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 todo.txt
 /storage/
 /utils/
+gunicorn.conf.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ venv
 *.local.*
 .env
 todo.txt
+/storage/
+/utils/

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,13 +1,14 @@
-import os
 from functools import wraps
 
 from flask import request, abort
+
+from core.config import Config
 
 
 def require_auth(view):
     @wraps(view)
     def wrapper_func(*args, **kwargs):
-        required_api_key = os.getenv("PODTUBE_API_KEY")
+        required_api_key = Config.get_required_api_key()
         request_api_key = request.args.get("api_key")
         if required_api_key is None or required_api_key == request_api_key:
             return view(*args, **kwargs)

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,16 @@
+import os
+from functools import wraps
+
+from flask import request, abort
+
+
+def require_auth(view):
+    @wraps(view)
+    def wrapper_func(*args, **kwargs):
+        required_api_key = os.getenv("PODTUBE_API_KEY")
+        request_api_key = request.args.get("api_key")
+        if required_api_key is None or required_api_key == request_api_key:
+            return view(*args, **kwargs)
+        else:
+            abort(401)
+    return wrapper_func

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,22 @@
+import os
+
+from core.plugin import Plugin
+
+
+class Config:
+    @staticmethod
+    def is_filesystem_mode_enabled(plugin: Plugin) -> bool:
+        global_fs_mode_enabled = get_bool_env('PODTUBE_FILESYSTEM_MODE')
+        plugin_fs_mode_enabled = get_bool_env(f'PODTUBE_FILESYSTEM_MODE_PLUGIN_{plugin.plugin_name}', plugin.default_fs_mode_enabled)
+        return global_fs_mode_enabled and plugin.supports_fs_mode and plugin_fs_mode_enabled
+
+    @staticmethod
+    def get_port():
+        port = os.getenv("PODTUBE_PORT")
+        return int(port) if port and port.isdigit() else 8080
+
+def get_bool_env(name, default=False):
+    str_value = os.getenv(name)
+    if str_value is None:
+        return default
+    return str_value.lower() == 'true'

--- a/core/config.py
+++ b/core/config.py
@@ -15,6 +15,14 @@ class Config:
         port = os.getenv("PODTUBE_PORT")
         return int(port) if port and port.isdigit() else 8080
 
+    @staticmethod
+    def get_required_api_key():
+        return os.getenv("PODTUBE_API_KEY")
+
+    @staticmethod
+    def get_preferred_plugin_for_service(service: str):
+        return os.getenv(f"PODTUBE_PLUGIN_{service}")
+
 def get_bool_env(name, default=False):
     str_value = os.getenv(name)
     if str_value is None:

--- a/core/feed.py
+++ b/core/feed.py
@@ -47,12 +47,9 @@ def render_feed(feed_id: str, plugin: Plugin, options: GlobalOptions, base_url: 
 def generate_url(
     episode: PodcastItem, plugin: Plugin, options: GlobalOptions, base_url: str
 ):
-    if options.proxy_url:
-        query_params = (
+    query_params = (
             options.model_dump(exclude_none=True)
             | plugin.options.model_dump(exclude_none=True)
             | {"id": episode.item_id}
-        )
-        return f"{base_url}download?" + urlencode(query_params)
-    else:
-        return plugin.get_item_url(episode.item_id)
+    )
+    return f"{base_url}download?" + urlencode(query_params)

--- a/core/migration.py
+++ b/core/migration.py
@@ -1,0 +1,26 @@
+from flask import redirect, url_for
+
+
+def handle_legacy_redirect(args, target):
+    service = args.get('service')
+    if service == 'youtube':
+        redirect_args = {
+            **args,
+            'service': 'youtube.com'
+        }
+    elif service == 'invidious':
+        redirect_args = {
+            **args,
+            'plugin': 'invidious'
+        }
+        del redirect_args['service']
+    elif service and '.' not in service:
+        redirect_args = {
+            **args,
+            'plugin': service
+        }
+        del redirect_args['service']
+    else:
+        return None
+
+    return redirect(url_for(target, **redirect_args), code=301)

--- a/core/model.py
+++ b/core/model.py
@@ -10,7 +10,7 @@ class PodcastItem:
     description: str
     link: str
     date: datetime
-    image: str
+    image: Optional[str]
     content_type: str
     content_length: Optional[str] = None
 

--- a/core/options.py
+++ b/core/options.py
@@ -10,9 +10,8 @@ class Options(BaseModel):
 class GlobalOptions(Options):
     service: Optional[constr(pattern=r"^[a-z.]+$")] = None
     plugin: Optional[constr(pattern=r"^[a-z]+$")] = None
-    id: constr(pattern=r"^[a-zA-Z0-9_-]+$")
+    id: constr(pattern=r"^[a-zA-Z0-9_\-:]+$")
     format: Literal["rss", "atom"] = "rss"
-    proxy_url: bool = True
     proxy_download: bool = False
     icon: HttpUrl | None = None
     api_key: Optional[constr(pattern=r"^[a-zA-Z0-9]+$")] = None
@@ -25,10 +24,3 @@ class GlobalOptions(Options):
         if self.service is not None and self.plugin is not None:
             raise ValueError("'service' and 'plugin' cannot be defined at the same time")
         return self
-
-
-class ServeOptions(Options):
-    namespace: constr(pattern=r"^[a-zA-Z0-9_-]+$")
-    id: constr(pattern=r"^[a-zA-Z0-9_-]+$")
-    service: Optional[constr(pattern=r"^[a-z.]+$")] = None
-    plugin: Optional[constr(pattern=r"^[a-z]+$")] = None

--- a/core/options.py
+++ b/core/options.py
@@ -25,3 +25,10 @@ class GlobalOptions(Options):
         if self.service is not None and self.plugin is not None:
             raise ValueError("'service' and 'plugin' cannot be defined at the same time")
         return self
+
+
+class ServeOptions(Options):
+    namespace: constr(pattern=r"^[a-zA-Z0-9_-]+$")
+    id: constr(pattern=r"^[a-zA-Z0-9_-]+$")
+    service: Optional[constr(pattern=r"^[a-z.]+$")] = None
+    plugin: Optional[constr(pattern=r"^[a-z]+$")] = None

--- a/core/options.py
+++ b/core/options.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Literal, Optional
 
-from pydantic import BaseModel, constr, HttpUrl
+from pydantic import BaseModel, constr, HttpUrl, model_validator
 
 
 class Options(BaseModel):
@@ -8,9 +8,20 @@ class Options(BaseModel):
 
 
 class GlobalOptions(Options):
-    service: constr(pattern=r"^[a-z]+$")
+    service: Optional[constr(pattern=r"^[a-z.]+$")] = None
+    plugin: Optional[constr(pattern=r"^[a-z]+$")] = None
     id: constr(pattern=r"^[a-zA-Z0-9_-]+$")
     format: Literal["rss", "atom"] = "rss"
     proxy_url: bool = True
     proxy_download: bool = False
     icon: HttpUrl | None = None
+    api_key: Optional[constr(pattern=r"^[a-zA-Z0-9]+$")] = None
+
+
+    @model_validator(mode='after')
+    def global_checks(self):
+        if self.service is None and self.plugin is None:
+            raise ValueError("Either 'service' or 'plugin' need to be defined")
+        if self.service is not None and self.plugin is not None:
+            raise ValueError("'service' and 'plugin' cannot be defined at the same time")
+        return self

--- a/core/plugin/__init__.py
+++ b/core/plugin/__init__.py
@@ -1,1 +1,3 @@
-from .plugin import *
+from .plugin import Plugin
+
+__all__ = ['Plugin']

--- a/core/plugin/plugin.py
+++ b/core/plugin/plugin.py
@@ -8,6 +8,8 @@ class Plugin(abc.ABC):
 
     service = None
     plugin_name = None
+    supports_fs_mode = False
+    default_fs_mode_enabled = False
 
     PluginOptions = Options  # Redefine the PluginOptions class on a plugin to set the specific plugin options.
 

--- a/core/plugin/plugin.py
+++ b/core/plugin/plugin.py
@@ -6,6 +6,9 @@ from core.options import Options
 
 class Plugin(abc.ABC):
 
+    service = None
+    plugin_name = None
+
     PluginOptions = Options  # Redefine the PluginOptions class on a plugin to set the specific plugin options.
 
     def __init__(self, options: dict[str, str]):

--- a/core/plugin/plugin_factory.py
+++ b/core/plugin/plugin_factory.py
@@ -1,3 +1,4 @@
+import os
 import pkgutil
 
 from importlib import import_module
@@ -5,10 +6,11 @@ from typing import Type
 
 from core.exceptions import InputError
 from core.plugin import Plugin
+from core.utils import find_first
 
 
 class PluginFactory:
-    plugins_dict: dict[str, Type[Plugin]] = {}
+    plugins: list[Type[Plugin]] = []
 
     @classmethod
     def autodiscover(cls):
@@ -21,15 +23,27 @@ class PluginFactory:
                 module_name = f"{plugins_package}.{name}"
                 module = import_module(module_name)
                 if hasattr(module, 'PluginImpl'):
-                    cls.plugins_dict[name] = module.PluginImpl
+                    module.PluginImpl.plugin_name = name
+                    cls.plugins.append(module.PluginImpl)
 
     @classmethod
-    def create(cls, service: str, options: dict[str, str]) -> Plugin:
-        if service not in cls.plugins_dict:
-            raise InputError(f"Invalid service {service} defined")
-        plugin_cls = cls.plugins_dict[service]
+    def create(cls, service: str | None, plugin_name: str | None, options: dict[str, str]) -> Plugin:
+        plugins = cls.get_plugins_from_service(service) if service else cls.get_plugins_from_plugin_name(plugin_name)
+        if len(plugins) == 0:
+            raise InputError(f"Invalid service '{service}' or plugin '{plugin_name}' defined")
+        plugin_cls = plugins[0]
         return plugin_cls(options)
 
+    @classmethod
+    def get_plugins_from_service(cls, service: str) -> list[Type[Plugin]]:
+        plugins = [plugin for plugin in cls.plugins if plugin.service == service]
+        preferred_plugin_name = os.getenv(f"PODTUBE_PLUGIN_{service}")
+        preferred_plugin = preferred_plugin_name and find_first(plugins, lambda x: x.plugin_name == preferred_plugin_name)
+        return [preferred_plugin] if preferred_plugin else plugins
+
+    @classmethod
+    def get_plugins_from_plugin_name(cls, plugin_name):
+        return [plugin for plugin in cls.plugins if plugin.plugin_name == plugin_name]
 
 # Usage
 PluginFactory.autodiscover()

--- a/core/plugin/plugin_factory.py
+++ b/core/plugin/plugin_factory.py
@@ -1,9 +1,9 @@
-import os
 import pkgutil
 
 from importlib import import_module
 from typing import Type
 
+from core.config import Config
 from core.exceptions import InputError
 from core.plugin import Plugin
 from core.utils import find_first
@@ -37,7 +37,7 @@ class PluginFactory:
     @classmethod
     def get_plugins_from_service(cls, service: str) -> list[Type[Plugin]]:
         plugins = [plugin for plugin in cls.plugins if plugin.service == service]
-        preferred_plugin_name = os.getenv(f"PODTUBE_PLUGIN_{service}")
+        preferred_plugin_name = Config.get_preferred_plugin_for_service(service)
         preferred_plugin = preferred_plugin_name and find_first(plugins, lambda x: x.plugin_name == preferred_plugin_name)
         return [preferred_plugin] if preferred_plugin else plugins
 

--- a/core/storage/files.py
+++ b/core/storage/files.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import BinaryIO, Optional
+
+@dataclass
+class FileInfo:
+    id: str
+    mimetype: str | None
+    filename: str
+
+@dataclass
+class SharedFile:
+    file_handle: BinaryIO
+    file_info: FileInfo

--- a/core/storage/files.py
+++ b/core/storage/files.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
-from typing import BinaryIO, Optional
+from datetime import datetime
+from typing import BinaryIO
 
 @dataclass
 class FileInfo:
     id: str
     mimetype: str | None
     filename: str
+    date: datetime
+    size: int
 
 @dataclass
 class SharedFile:

--- a/core/storage/hasher.py
+++ b/core/storage/hasher.py
@@ -1,0 +1,5 @@
+import xxhash
+
+class Hasher:
+    def hash(self, data: str) -> str:
+        return xxhash.xxh3_64_hexdigest(data)

--- a/core/storage/storage.py
+++ b/core/storage/storage.py
@@ -2,32 +2,57 @@ import glob
 import mimetypes
 import os
 from collections import OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
 
+from core.exceptions import InputError
 from core.plugin.plugin import Plugin
 from core.storage.hasher import Hasher
 from core.storage.files import SharedFile, FileInfo
 
+
 class Storage:
     def __init__(self, plugin: Plugin):
-        self.path = f'storage/{plugin.plugin_name}'
+        self.base_path = Path('storage').joinpath(plugin.plugin_name).resolve()
         self.hasher = Hasher()
 
     def list_items(self, namespace: str) -> list[FileInfo]:
-        return [FileInfo(id=id, mimetype=mimetypes.guess_type(filename)[0], filename=filename) for id, filename in self._get_namespace_files(namespace).items()]
+        return [self._build_file_info(file_id, filename, namespace) for file_id, filename in self._get_namespace_files(namespace).items()]
 
-    def serve(self, namespace: str, id: str) -> SharedFile:
-        path = self.path + f'/{namespace}/'
-        filename = self._get_namespace_files(namespace)[id]
+    def _build_file_info(self, file_id: str, filename: str, namespace: str):
+        full_filename = self.path(namespace, filename)
+        return FileInfo(
+            id=file_id,
+            mimetype=mimetypes.guess_type(full_filename)[0],
+            filename=filename,
+            date=self._datetime_from_path(full_filename),
+            size=os.path.getsize(full_filename)
+        )
+
+    def serve(self, namespace: str, file_id: str) -> SharedFile:
+        filename = self._get_namespace_files(namespace)[file_id]
+        full_filename = self.path(namespace, filename)
         return SharedFile(
-            file_handle=open(path + filename, 'rb'),
+            file_handle=open(full_filename, 'rb'),
             file_info=FileInfo(
-                id=id,
-                mimetype=mimetypes.guess_type(filename)[0],
-                filename=filename
+                id=file_id,
+                mimetype=mimetypes.guess_type(full_filename)[0],
+                filename=filename,
+                date=self._datetime_from_path(full_filename),
+                size=os.path.getsize(full_filename)
             )
         )
 
     def _get_namespace_files(self, namespace: str) -> dict[str, str]:
-        path = self.path + f'/{namespace}/'
-        items = sorted(glob.glob('*', root_dir=path), key=lambda x: os.path.getmtime(f"{path}{x}"))
+        items = sorted(glob.glob('*', root_dir=self.path(namespace)), key=lambda x: os.path.getmtime(self.path(namespace, x)))
         return OrderedDict((self.hasher.hash(item), item) for item in items)
+
+    def _datetime_from_path(self, path: Path):
+        return datetime.fromtimestamp(os.path.getmtime(path), timezone.utc)
+
+    def path(self, *path_parts: str):
+        path = self.base_path.joinpath(*path_parts).resolve()
+        if path.is_relative_to(self.base_path):
+            return path
+        else:
+            raise InputError

--- a/core/storage/storage.py
+++ b/core/storage/storage.py
@@ -2,7 +2,6 @@ import glob
 import mimetypes
 import os
 from collections import OrderedDict
-from typing import BinaryIO
 
 from core.plugin.plugin import Plugin
 from core.storage.hasher import Hasher

--- a/core/storage/storage.py
+++ b/core/storage/storage.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 
+from core.config import Config
 from core.exceptions import InputError
 from core.plugin.plugin import Plugin
 from core.storage.hasher import Hasher
@@ -15,23 +16,16 @@ class Storage:
     def __init__(self, plugin: Plugin):
         self.base_path = Path('storage').joinpath(plugin.plugin_name).resolve()
         self.hasher = Hasher()
+        self.plugin = plugin
 
     def list_items(self, namespace: str) -> list[FileInfo]:
+        self._assert_permissions()
         return [self._build_file_info(file_id, filename, namespace) for file_id, filename in self._get_namespace_files(namespace).items()]
 
-    def _build_file_info(self, file_id: str, filename: str, namespace: str):
-        full_filename = self.path(namespace, filename)
-        return FileInfo(
-            id=file_id,
-            mimetype=mimetypes.guess_type(full_filename)[0],
-            filename=filename,
-            date=self._datetime_from_path(full_filename),
-            size=os.path.getsize(full_filename)
-        )
-
     def serve(self, namespace: str, file_id: str) -> SharedFile:
+        self._assert_permissions()
         filename = self._get_namespace_files(namespace)[file_id]
-        full_filename = self.path(namespace, filename)
+        full_filename = self._path(namespace, filename)
         return SharedFile(
             file_handle=open(full_filename, 'rb'),
             file_info=FileInfo(
@@ -43,16 +37,30 @@ class Storage:
             )
         )
 
+    def _build_file_info(self, file_id: str, filename: str, namespace: str):
+        full_filename = self._path(namespace, filename)
+        return FileInfo(
+            id=file_id,
+            mimetype=mimetypes.guess_type(full_filename)[0],
+            filename=filename,
+            date=self._datetime_from_path(full_filename),
+            size=os.path.getsize(full_filename)
+        )
+
     def _get_namespace_files(self, namespace: str) -> dict[str, str]:
-        items = sorted(glob.glob('*', root_dir=self.path(namespace)), key=lambda x: os.path.getmtime(self.path(namespace, x)))
+        items = sorted(glob.glob('*', root_dir=self._path(namespace)), key=lambda x: os.path.getmtime(self._path(namespace, x)))
         return OrderedDict((self.hasher.hash(item), item) for item in items)
 
     def _datetime_from_path(self, path: Path):
         return datetime.fromtimestamp(os.path.getmtime(path), timezone.utc)
 
-    def path(self, *path_parts: str):
+    def _path(self, *path_parts: str):
         path = self.base_path.joinpath(*path_parts).resolve()
         if path.is_relative_to(self.base_path):
             return path
         else:
+            raise InputError
+
+    def _assert_permissions(self):
+        if not Config.is_filesystem_mode_enabled(self.plugin):
             raise InputError

--- a/core/storage/storage.py
+++ b/core/storage/storage.py
@@ -1,0 +1,34 @@
+import glob
+import mimetypes
+import os
+from collections import OrderedDict
+from typing import BinaryIO
+
+from core.plugin.plugin import Plugin
+from core.storage.hasher import Hasher
+from core.storage.files import SharedFile, FileInfo
+
+class Storage:
+    def __init__(self, plugin: Plugin):
+        self.path = f'storage/{plugin.plugin_name}'
+        self.hasher = Hasher()
+
+    def list_items(self, namespace: str) -> list[FileInfo]:
+        return [FileInfo(id=id, mimetype=mimetypes.guess_type(filename)[0], filename=filename) for id, filename in self._get_namespace_files(namespace).items()]
+
+    def serve(self, namespace: str, id: str) -> SharedFile:
+        path = self.path + f'/{namespace}/'
+        filename = self._get_namespace_files(namespace)[id]
+        return SharedFile(
+            file_handle=open(path + filename, 'rb'),
+            file_info=FileInfo(
+                id=id,
+                mimetype=mimetypes.guess_type(filename)[0],
+                filename=filename
+            )
+        )
+
+    def _get_namespace_files(self, namespace: str) -> dict[str, str]:
+        path = self.path + f'/{namespace}/'
+        items = sorted(glob.glob('*', root_dir=path), key=lambda x: os.path.getmtime(f"{path}{x}"))
+        return OrderedDict((self.hasher.hash(item), item) for item in items)

--- a/core/utils.py
+++ b/core/utils.py
@@ -10,3 +10,9 @@ def safe_traverse(input_data, *args):
         except Exception:
             return None
     return current
+
+def find_first(iterable, function = lambda x: True):
+    for item in iterable:
+        if function(item):
+            return item
+    return None

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import os
 
 import httpx
 from dotenv import load_dotenv
@@ -59,12 +58,13 @@ def download():
     if Config.is_filesystem_mode_enabled(plugin):
         namespace, item_id = options.id.split(":")
         storage = Storage(plugin)
-        shared_file = storage.serve(namespace=namespace, id=item_id)
+        shared_file = storage.serve(namespace=namespace, file_id=item_id)
         return Response(
             stream_with_context(generate_file(shared_file.file_handle)),
             content_type=shared_file.file_info.mimetype,
             headers={
-                'Content-Disposition': f'attachment; filename="{shared_file.file_info.filename}"'
+                'Content-Disposition': f'attachment; filename="{shared_file.file_info.filename}"',
+                'Content-Length': shared_file.file_info.size
             },
         )
     elif options.proxy_download:

--- a/plugins/filesystem.py
+++ b/plugins/filesystem.py
@@ -36,7 +36,8 @@ class PluginImpl(Plugin):
             title=item.filename.split(".")[0],
             description="",
             link="",
-            date=None,
+            date=item.date,
             image=None,
             content_type=item.mimetype or "",
+            content_length=str(item.size)
         )

--- a/plugins/filesystem.py
+++ b/plugins/filesystem.py
@@ -1,21 +1,13 @@
-from datetime import datetime
-from typing import List, Literal
-from typing_extensions import ItemsView
-
-import httpx
-from parsel import Selector, SelectorList
-from yt_dlp import YoutubeDL
-
-from ytdl_config import ytdl_opts
 from core.model import PodcastItem, PodcastFeed
-from core.exceptions import PluginError
-from core.options import Options
 from core.plugin.plugin import Plugin
 from core.storage.files import FileInfo
 from core.storage.storage import Storage
 
 
 class PluginImpl(Plugin):
+    supports_fs_mode = True
+    default_fs_mode_enabled = True
+
     def __init__(self, options):
         super().__init__(options)
         self.storage = Storage(self)
@@ -33,8 +25,7 @@ class PluginImpl(Plugin):
         )
 
     def get_item_url(self, item_id):
-        feed_id, item = item_id.split(":")
-        return f"http://<base_url>/serve?plugin=filesystem&id={item}&namespace={feed_id}" # TODO
+        raise NotImplementedError()
 
     def _get_items(self, feed_id: str, items: list[FileInfo]) -> list[PodcastItem]:
         return [self._get_item(feed_id, item) for item in items]

--- a/plugins/filesystem.py
+++ b/plugins/filesystem.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import List, Literal
+from typing_extensions import ItemsView
+
+import httpx
+from parsel import Selector, SelectorList
+from yt_dlp import YoutubeDL
+
+from ytdl_config import ytdl_opts
+from core.model import PodcastItem, PodcastFeed
+from core.exceptions import PluginError
+from core.options import Options
+from core.plugin.plugin import Plugin
+from core.storage.files import FileInfo
+from core.storage.storage import Storage
+
+
+class PluginImpl(Plugin):
+    def __init__(self, options):
+        super().__init__(options)
+        self.storage = Storage(self)
+
+    def get_feed(self, feed_id):
+        items = self.storage.list_items(feed_id)
+
+        return PodcastFeed(
+            feed_id=feed_id,
+            title=feed_id,
+            description=feed_id,
+            link="https://github.com/dyeray/podtube/",
+            image="",
+            items=self._get_items(feed_id, items),
+        )
+
+    def get_item_url(self, item_id):
+        feed_id, item = item_id.split(":")
+        return f"http://<base_url>/serve?plugin=filesystem&id={item}&namespace={feed_id}" # TODO
+
+    def _get_items(self, feed_id: str, items: list[FileInfo]) -> list[PodcastItem]:
+        return [self._get_item(feed_id, item) for item in items]
+
+    def _get_item(self, feed_id: str, item: FileInfo):
+        return PodcastItem(
+            item_id=f'{feed_id}:{item.id}',
+            title=item.filename.split(".")[0],
+            description="",
+            link="",
+            date=None,
+            image=None,
+            content_type=item.mimetype or "",
+        )

--- a/plugins/instagram.py
+++ b/plugins/instagram.py
@@ -10,10 +10,15 @@ from core.exceptions import PluginError
 from core.model import PodcastFeed, PodcastItem
 from core.plugin.plugin import Plugin
 from core.utils import safe_traverse
+from ytdl_config import ytdl_opts
 
 
 class PluginImpl(Plugin):
     service = "instagram.com"
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.resolver = YoutubeDL(ytdl_opts)
 
     def get_feed(self, feed_id):
         """Calculates and returns the subscribable feed."""
@@ -49,7 +54,7 @@ class PluginImpl(Plugin):
             # It would be possible to get the video by accessing data API key 'video_url'. Issues:
             # * If we return the url directly when genrating the feed, url may expire before download.
             # * If we call data API when user requests download, info about that video might not be there anymore.
-            return YoutubeDL().extract_info(
+            return self.resolver.extract_info(
                 self._get_story_url(item_id), download=False
             )["url"]
         except Exception as ex:

--- a/plugins/ivoox.py
+++ b/plugins/ivoox.py
@@ -57,8 +57,8 @@ class PluginImpl(Plugin):
         ]
 
     def _get_item(self, item: Selector) -> Union[PodcastItem, None]:
-        has_support_badge = item.css(".title-wrapper span.fan-title").get() != None
-        if has_support_badge == True:
+        has_support_badge = item.css(".title-wrapper span.fan-title").get() is not None
+        if has_support_badge:
             return None
         url = item.css(".title-wrapper a::attr(href)").get()
         re_item_id = re.match(r"https?://www\.ivoox\.com/([-_\w\d]+)\.html", url)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-pytest==8.1.1
+pytest==8.3.4
 pytest-mock==3.14.0
-pytest-httpx==0.30.0
+pytest-httpx==0.35.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
 pytest==8.3.4
 pytest-mock==3.14.0
 pytest-httpx==0.35.0
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pod2gen==1.0.3
-yt-dlp==2024.8.6
+yt-dlp==2024.12.6
 flask==3.0.3
 gunicorn==23.0.0
 httpx==0.27.0
@@ -8,3 +8,4 @@ dateparser==1.2.0
 pydantic==2.8.2
 ftfy==6.2.3
 python-dotenv==1.0.1
+xxhash==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 pod2gen==1.0.3
-yt-dlp==2024.12.6
-flask==3.0.3
+yt-dlp==2024.12.23
+flask==3.1.0
 gunicorn==23.0.0
-httpx==0.27.0
+httpx==0.28.1
 parsel==1.9.1
 dateparser==1.2.0
-pydantic==2.8.2
-ftfy==6.2.3
+pydantic==2.10.4
+ftfy==6.3.1
 python-dotenv==1.0.1
 xxhash==3.5.0

--- a/ytdl_config.py
+++ b/ytdl_config.py
@@ -9,4 +9,4 @@ class MyLogger:
         print(msg)
 
 
-ytdl_opts = {"format": "(mp4)[height <= 720]", "logger": MyLogger()}
+ytdl_opts = {"format": "(mp4)[height <= 720]/best", "logger": MyLogger()}

--- a/ytdl_config.py
+++ b/ytdl_config.py
@@ -9,4 +9,4 @@ class MyLogger:
         print(msg)
 
 
-ytdl_opts = {"format": "(mp4)[height <= 720]/best", "logger": MyLogger()}
+ytdl_opts = {"format": "best[protocol=https]/best[protocol=http]", "logger": MyLogger()}


### PR DESCRIPTION
Expected changes:

* offline mode: there would be either a cronjob, or the first time an item is tried download we return a temporarily unavailable and download it locally. if the item is present locally, we just serve it. This mode will allow to have a: file serve plugin, mitele.es plugin, offline youtube plugin (with support for subtitles and better compatibility), etc. Plugins that make use of offline mode may come later.
* Possibility to set API key on url to protect your instance from bot attacks or leechers, specially with offline mode.
* update on url scheme. Now service will represent which service you want to access, while allowing to specify the preferred plugin in config (for example invidious or youtube). This will allow for a quick fix if invidious or youtube-dl are failing atm. To more precise control from the url, the old service query param will now be plugin query param, and a permanent redirect should update legacy urls so they have the same behavior.